### PR TITLE
support the Handler interface on the Command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
   - 1.2
+  - 1.4
   - tip

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [API documentation is available on godoc.org](http://godoc.org/github.com/Pu
 
 ## Changes
 
-* 2015-07-23 : add `HandlerCmd` and call the Command's `Handler` function if it implements the `Handler` interface, bypassing the `Fetcher`'s handler.
+* 2015-07-24 : add `HandlerCmd` and call the Command's `Handler` function if it implements the `Handler` interface, bypassing the `Fetcher`'s handler. Support a `Custom` matcher on the `Mux`, using a predicate. (thanks to [@mmcdole][mmcdole] for the feature requests).
 * 2015-06-18 : add `Scheme` criteria on the muxer (thanks to [@buro9][buro9]).
 * 2015-06-10 : add `DisablePoliteness` field on the `Fetcher` to optionally bypass robots.txt checks (thanks to [@oli-g][oli]).
 * 2014-07-04 : change the type of Fetcher.HttpClient from `*http.Client` to the `Doer` interface. Low chance of breaking existing code, but it's a possibility if someone used the fetcher's client to run other requests (e.g. `f.HttpClient.Get(...)`).
@@ -166,3 +166,4 @@ the source file).
 
 [oli]: https://github.com/oli-g
 [buro9]: https://github.com/buro9
+[mmcdole]: https://github.com/mmcdole

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fetchbot
+# fetchbot [![build status](https://secure.travis-ci.org/PuerkitoBio/fetchbot.png)](http://travis-ci.org/PuerkitoBio/fetchbot) [![GoDoc](https://godoc.org/github.com/PuerkitoBio/fetchbot?status.png)](http://godoc.org/github.com/PuerkitoBio/fetchbot)
 
 Package fetchbot provides a simple and flexible web crawler that follows the robots.txt
 policies and crawl delays.
@@ -6,10 +6,6 @@ policies and crawl delays.
 It is very much a rewrite of [gocrawl](https://github.com/PuerkitoBio/gocrawl) with a
 simpler API, less features built-in, but at the same time more flexibility. As for Go
 itself, sometimes less is more!
-
-[![build status](https://secure.travis-ci.org/PuerkitoBio/fetchbot.png)](http://travis-ci.org/PuerkitoBio/fetchbot)
-
-[![GoDoc](https://godoc.org/github.com/PuerkitoBio/fetchbot?status.png)](http://godoc.org/github.com/PuerkitoBio/fetchbot)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ itself, sometimes less is more!
 
 [![build status](https://secure.travis-ci.org/PuerkitoBio/fetchbot.png)](http://travis-ci.org/PuerkitoBio/fetchbot)
 
+[![GoDoc](https://godoc.org/github.com/PuerkitoBio/fetchbot?status.png)](http://godoc.org/github.com/PuerkitoBio/fetchbot)
+
 ## Installation
 
 To install, simply run in a terminal:
@@ -21,6 +23,7 @@ The [API documentation is available on godoc.org](http://godoc.org/github.com/Pu
 
 ## Changes
 
+* 2015-07-23 : add `HandlerCmd` and call the Command's `Handler` function if it implements the `Handler` interface, bypassing the `Fetcher`'s handler.
 * 2015-06-18 : add `Scheme` criteria on the muxer (thanks to [@buro9][buro9]).
 * 2015-06-10 : add `DisablePoliteness` field on the `Fetcher` to optionally bypass robots.txt checks (thanks to [@oli-g][oli]).
 * 2014-07-04 : change the type of Fetcher.HttpClient from `*http.Client` to the `Doer` interface. Low chance of breaking existing code, but it's a possibility if someone used the fetcher's client to run other requests (e.g. `f.HttpClient.Get(...)`).
@@ -57,9 +60,11 @@ commands have been handled.
 
 A more complex and complete example can be found in the repository, at /example/full/.
 
-Basically, a Fetcher is an instance of a web crawler, independent of other Fetchers.
-It receives Commands via the Queue, executes the requests, and calls a Handler to
-process the responses. A Command is an interface that tells the Fetcher which URL to
+### Fetcher
+
+Basically, a **Fetcher** is an instance of a web crawler, independent of other Fetchers.
+It receives Commands via the **Queue**, executes the requests, and calls a **Handler** to
+process the responses. A **Command** is an interface that tells the Fetcher which URL to
 fetch, and which HTTP method to use (i.e. "GET", "HEAD", ...).
 
 A call to Fetcher.Start() returns the Queue associated with this Fetcher. This is the
@@ -76,7 +81,7 @@ They are defined like so:
     	Handle(*Context, *http.Response, error)
     }
 
-A Context is a struct that holds the Command and the Queue, so that the Handler always
+A **Context** is a struct that holds the Command and the Queue, so that the Handler always
 knows which Command initiated this call, and has a handle to the Queue.
 
 A Handler is similar to the net/http Handler, and middleware-style combinations can
@@ -85,19 +90,33 @@ with the right signature can be used as Handlers (like net/http.HandlerFunc), an
 is also a multiplexer Mux that can be used to dispatch calls to different Handlers
 based on some criteria.
 
-The Fetcher recognizes a number of interfaces that the Command may implement, for
-more advanced needs. If the Command implements the BasicAuthProvider interface,
-a Basic Authentication header will be put in place with the given credentials
-to fetch the URL.
+### Command-related Interfaces
 
-Similarly, the CookiesProvider and HeaderProvider interfaces offer the expected
-features (setting cookies and header values on the request). The ReaderProvider
-and ValuesProvider interfaces are also supported, although they should be mutually
-exclusive as they both set the body of the request. If both are supported, the
-ReaderProvider interface is used. It sets the body of the request (e.g. for a "POST")
-using the given io.Reader instance. The ValuesProvider does the same, but using
-the given url.Values instance, and sets the Content-Type of the body to
-"application/x-www-form-urlencoded" (unless it is explicitly set by a HeaderProvider).
+The Fetcher recognizes a number of interfaces that the Command may implement, for
+more advanced needs.
+
+* `BasicAuthProvider`: Implement this interface to specify the basic authentication
+credentials to set on the request.
+
+* `CookiesProvider`: If the Command implements this interface, the provided Cookies
+will be set on the request.
+
+* `HeaderProvider`: Implement this interface to specify the headers to set on the
+request. 
+
+* `ReaderProvider`: Implement this interface to set the body of the request, via
+an `io.Reader`.
+
+* `ValuesProvider`: Implement this interface to set the body of the request, as
+form-encoded values. If the Content-Type is not specifically set via a `HeaderProvider`,
+it is set to "application/x-www-form-urlencoded". `ReaderProvider` and `ValuesProvider` 
+should be mutually exclusive as they both set the body of the request. If both are 
+implemented, the `ReaderProvider` interface is used.
+
+* `Handler`: Implement this interface if the Command's response should be handled
+by a specific callback function. By default, the response is handled by the Fetcher's
+Handler, but if the Command implements this, this handler function takes precedence
+and the Fetcher's Handler is ignored.
 
 Since the Command is an interface, it can be a custom struct that holds additional
 information, such as an ID for the URL (e.g. from a database), or a depth counter
@@ -106,21 +125,31 @@ require additional information, the package provides the Cmd struct that impleme
 the Command interface. This is the Command implementation used when using the
 various Queue.SendString\* methods.
 
+There is also a convenience `HandlerCmd` struct for the commands that should be handled
+by a specific callback function. It is a Command with a Handler interface implementation.
+
+### Fetcher Options
+
 The Fetcher has a number of fields that provide further customization:
 
-- HttpClient : By default, the Fetcher uses the net/http default Client to make requests. A
+* HttpClient : By default, the Fetcher uses the net/http default Client to make requests. A
 different client can be set on the Fetcher.HttpClient field.
 
-- CrawlDelay : That value is used only if there is no delay specified
+* CrawlDelay : That value is used only if there is no delay specified
 by the robots.txt of a given host.
 
-- UserAgent : Sets the user agent string to use for the requests and to validate
+* UserAgent : Sets the user agent string to use for the requests and to validate
 against the robots.txt entries.
 
-- WorkerIdleTTL : Sets the duration that a worker goroutine can wait without receiving
+* WorkerIdleTTL : Sets the duration that a worker goroutine can wait without receiving
 new commands to fetch. If the idle time-to-live is reached, the worker goroutine
 is stopped and its resources are released. This can be especially useful for
 long-running crawlers.
+
+* AutoClose : If true, closes the queue automatically once the number of active hosts
+reach 0.
+
+* DisablePoliteness : If true, ignores the robots.txt policies of the hosts.
 
 What fetchbot doesn't do - especially compared to gocrawl - is that it doesn't
 keep track of already visited URLs, and it doesn't normalize the URLs. This is outside

--- a/cmd.go
+++ b/cmd.go
@@ -10,27 +10,27 @@ import (
 	"net/url"
 )
 
-// The Command interface defines the methods required by the Fetcher to request
+// Command interface defines the methods required by the Fetcher to request
 // a resource.
 type Command interface {
 	URL() *url.URL
 	Method() string
 }
 
-// The BasicAuthProvider interface gets the credentials to use to perform the request
+// BasicAuthProvider interface gets the credentials to use to perform the request
 // with Basic Authentication.
 type BasicAuthProvider interface {
 	BasicAuth() (user string, pwd string)
 }
 
-// The ReaderProvider interface gets the Reader to use as the Body of the request. It has
+// ReaderProvider interface gets the Reader to use as the Body of the request. It has
 // higher priority than the ValuesProvider interface, so that if both interfaces are implemented,
 // the ReaderProvider is used.
 type ReaderProvider interface {
 	Reader() io.Reader
 }
 
-// The ValuesProvider interface gets the values to send as the Body of the request. It has
+// ValuesProvider interface gets the values to send as the Body of the request. It has
 // lower priority than the ReaderProvider interface, so that if both interfaces are implemented,
 // the ReaderProvider is used. If the request has no explicit Content-Type set, it will be automatically
 // set to "application/x-www-form-urlencoded".
@@ -38,18 +38,18 @@ type ValuesProvider interface {
 	Values() url.Values
 }
 
-// The CookiesProvider interface gets the cookies to send with the request.
+// CookiesProvider interface gets the cookies to send with the request.
 type CookiesProvider interface {
 	Cookies() []*http.Cookie
 }
 
-// The HeaderProvider interface gets the headers to set on the request. If an Authorization
+// HeaderProvider interface gets the headers to set on the request. If an Authorization
 // header is set, it will be overridden by the BasicAuthProvider, if implemented.
 type HeaderProvider interface {
 	Header() http.Header
 }
 
-// The Cmd struct defines a basic Command implementation.
+// Cmd defines a basic Command implementation.
 type Cmd struct {
 	U *url.URL
 	M string
@@ -63,6 +63,23 @@ func (c *Cmd) URL() *url.URL {
 // Method returns the HTTP verb to use to process this command (i.e. "GET", "HEAD", etc.).
 func (c *Cmd) Method() string {
 	return c.M
+}
+
+// HandlerCmd is a basic Command with its own Handler function that is called
+// to handle the HTTP response.
+type HandlerCmd struct {
+	*Cmd
+	HandlerFunc
+}
+
+// NewHandlerCmd creates a HandlerCmd for the provided request and callback
+// handler function.
+func NewHandlerCmd(method, rawURL string, fn func(*Context, *http.Response, error)) (*HandlerCmd, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return &HandlerCmd{&Cmd{parsedURL, method}, HandlerFunc(fn)}, nil
 }
 
 // robotCommand is a "sentinel type" used to distinguish the automatically enqueued robots.txt

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -43,24 +43,24 @@ func TestBasicAuth(t *testing.T) {
 		status int
 	}{
 		0: {
-			&basicAuthCmd{&Cmd{U: mustParse(srv.URL + "/a"), M: "GET"}, "me", "you"},
+			&basicAuthCmd{&Cmd{U: mustParse(t, srv.URL+"/a"), M: "GET"}, "me", "you"},
 			http.StatusOK,
 		},
 		1: {
-			&Cmd{U: mustParse(srv.URL + "/b"), M: "GET"},
+			&Cmd{U: mustParse(t, srv.URL+"/b"), M: "GET"},
 			http.StatusUnauthorized,
 		},
 		2: {
-			&basicAuthCmd{&Cmd{U: mustParse(srv.URL + "/c"), M: "GET"}, "some", "other"},
+			&basicAuthCmd{&Cmd{U: mustParse(t, srv.URL+"/c"), M: "GET"}, "some", "other"},
 			http.StatusUnauthorized,
 		},
 		3: {
-			&readerCmd{&Cmd{U: mustParse(srv.URL + "/d"), M: "POST"},
+			&readerCmd{&Cmd{U: mustParse(t, srv.URL+"/d"), M: "POST"},
 				strings.NewReader("a")},
 			http.StatusUnauthorized,
 		},
 		4: {
-			&valuesCmd{&Cmd{U: mustParse(srv.URL + "/e"), M: "POST"},
+			&valuesCmd{&Cmd{U: mustParse(t, srv.URL+"/e"), M: "POST"},
 				url.Values{"k": {"v"}}},
 			http.StatusUnauthorized,
 		},
@@ -143,30 +143,30 @@ func TestBody(t *testing.T) {
 		body string
 	}{
 		0: {
-			&readerCmd{&Cmd{U: mustParse(srv.URL + "/a"), M: "POST"},
+			&readerCmd{&Cmd{U: mustParse(t, srv.URL+"/a"), M: "POST"},
 				strings.NewReader("a")},
 			"a",
 		},
 		1: {
-			&valuesCmd{&Cmd{U: mustParse(srv.URL + "/b"), M: "POST"},
+			&valuesCmd{&Cmd{U: mustParse(t, srv.URL+"/b"), M: "POST"},
 				url.Values{"k": {"v"}}},
 			"k=v",
 		},
 		2: {
-			&Cmd{U: mustParse(srv.URL + "/c"), M: "POST"},
+			&Cmd{U: mustParse(t, srv.URL+"/c"), M: "POST"},
 			"",
 		},
 		3: {
-			&basicAuthCmd{&Cmd{U: mustParse(srv.URL + "/d"), M: "POST"}, "me", "you"},
+			&basicAuthCmd{&Cmd{U: mustParse(t, srv.URL+"/d"), M: "POST"}, "me", "you"},
 			"",
 		},
 		4: {
-			&cookiesCmd{&Cmd{U: mustParse(srv.URL + "/e"), M: "GET"},
+			&cookiesCmd{&Cmd{U: mustParse(t, srv.URL+"/e"), M: "GET"},
 				[]*http.Cookie{&http.Cookie{Name: "e"}}},
 			"e",
 		},
 		5: {
-			&cookiesCmd{&Cmd{U: mustParse(srv.URL + "/f"), M: "GET"},
+			&cookiesCmd{&Cmd{U: mustParse(t, srv.URL+"/f"), M: "GET"},
 				[]*http.Cookie{&http.Cookie{Name: "f1"}, &http.Cookie{Name: "f2"}}},
 			"f1&f2",
 		},
@@ -225,16 +225,16 @@ func TestHeader(t *testing.T) {
 		body string
 	}{
 		0: {
-			&headerCmd{&Cmd{U: mustParse(srv.URL + "/a"), M: "GET"},
+			&headerCmd{&Cmd{U: mustParse(t, srv.URL+"/a"), M: "GET"},
 				http.Header{"A": {"a"}}},
 			"A:a\n",
 		},
 		1: {
-			&Cmd{U: mustParse(srv.URL + "/b"), M: "GET"},
+			&Cmd{U: mustParse(t, srv.URL+"/b"), M: "GET"},
 			"",
 		},
 		2: {
-			&headerCmd{&Cmd{U: mustParse(srv.URL + "/c"), M: "GET"},
+			&headerCmd{&Cmd{U: mustParse(t, srv.URL+"/c"), M: "GET"},
 				http.Header{"C": {"c"}, "D": {"d"}}},
 			"C:c\nD:d\n",
 		},
@@ -330,7 +330,7 @@ func TestFullCmd(t *testing.T) {
 	f.CrawlDelay = 0
 	q := f.Start()
 	cmd := &fullCmd{
-		&Cmd{U: mustParse(srv.URL + "/a"), M: "POST"},
+		&Cmd{U: mustParse(t, srv.URL+"/a"), M: "POST"},
 		"me", "you",
 		strings.NewReader("body"),
 		url.Values{"ignored": {"val"}},
@@ -352,10 +352,10 @@ func TestFullCmd(t *testing.T) {
 	}
 }
 
-func mustParse(raw string) *url.URL {
+func mustParse(t *testing.T, raw string) *url.URL {
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return parsed
 }

--- a/doc.go
+++ b/doc.go
@@ -55,6 +55,8 @@ commands have been handled.
 
 A more complex and complete example can be found in the repository, at /example/full/.
 
+Fetcher
+
 Basically, a Fetcher is an instance of a web crawler, independent of other Fetchers.
 It receives Commands via the Queue, executes the requests, and calls a Handler to
 process the responses. A Command is an interface that tells the Fetcher which URL to
@@ -83,45 +85,66 @@ with the right signature can be used as Handlers (like net/http.HandlerFunc), an
 is also a multiplexer Mux that can be used to dispatch calls to different Handlers
 based on some criteria.
 
-The Fetcher recognizes a number of interfaces that the Command may implement, for
-more advanced needs. If the Command implements the BasicAuthProvider interface,
-a Basic Authentication header will be put in place with the given credentials
-to fetch the URL.
+Command-related Interfaces
 
-Similarly, the CookiesProvider and HeaderProvider interfaces offer the expected
-features (setting cookies and header values on the request). The ReaderProvider
-and ValuesProvider interfaces are also supported, although they should be mutually
-exclusive as they both set the body of the request. If both are supported, the
-ReaderProvider interface is used. It sets the body of the request (e.g. for a "POST")
-using the given io.Reader instance. The ValuesProvider does the same, but using
-the given url.Values instance, and sets the Content-Type of the body to
-"application/x-www-form-urlencoded" (unless it is explicitly set by a HeaderProvider).
+The Fetcher recognizes a number of interfaces that the Command may implement, for
+more advanced needs.
+
+* BasicAuthProvider: Implement this interface to specify the basic authentication
+credentials to set on the request.
+
+* CookiesProvider: If the Command implements this interface, the provided Cookies
+will be set on the request.
+
+* HeaderProvider: Implement this interface to specify the headers to set on the
+request.
+
+* ReaderProvider: Implement this interface to set the body of the request, via
+an io.Reader.
+
+* ValuesProvider: Implement this interface to set the body of the request, as
+form-encoded values. If the Content-Type is not specifically set via a HeaderProvider,
+it is set to "application/x-www-form-urlencoded". ReaderProvider and ValuesProvider
+should be mutually exclusive as they both set the body of the request. If both are
+implemented, the ReaderProvider interface is used.
+
+* Handler: Implement this interface if the Command's response should be handled
+by a specific callback function. By default, the response is handled by the Fetcher's
+Handler, but if the Command implements this, this handler function takes precedence
+and the Fetcher's Handler is ignored.
 
 Since the Command is an interface, it can be a custom struct that holds additional
 information, such as an ID for the URL (e.g. from a database), or a depth counter
 so that the crawling stops at a certain depth, etc. For basic commands that don't
 require additional information, the package provides the Cmd struct that implements
 the Command interface. This is the Command implementation used when using the
-various Queue.SendString* methods.
+various Queue.SendString\* methods.
+
+There is also a convenience HandlerCmd struct for the commands that should be handled
+by a specific callback function. It is a Command with a Handler interface implementation.
+
+Fetcher Options
 
 The Fetcher has a number of fields that provide further customization:
 
-- HttpClient : By default, the Fetcher uses the net/http default Client to make requests. A
+* HttpClient : By default, the Fetcher uses the net/http default Client to make requests. A
 different client can be set on the Fetcher.HttpClient field.
 
-- CrawlDelay : That value is used only if there is no delay specified
+* CrawlDelay : That value is used only if there is no delay specified
 by the robots.txt of a given host.
 
-- UserAgent : Sets the user agent string to use for the requests and to validate
+* UserAgent : Sets the user agent string to use for the requests and to validate
 against the robots.txt entries.
 
-- WorkerIdleTTL : Sets the duration that a worker goroutine can wait without receiving
+* WorkerIdleTTL : Sets the duration that a worker goroutine can wait without receiving
 new commands to fetch. If the idle time-to-live is reached, the worker goroutine
 is stopped and its resources are released. This can be especially useful for
 long-running crawlers.
 
-- DisablePoliteness : If true, disables fetching of robots.txt, effectively
-forcing the use of the CrawlDelay value between calls to a host.
+* AutoClose : If true, closes the queue automatically once the number of active hosts
+reach 0.
+
+* DisablePoliteness : If true, ignores the robots.txt policies of the hosts.
 
 What fetchbot doesn't do - especially compared to gocrawl - is that it doesn't
 keep track of already visited URLs, and it doesn't normalize the URLs. This is outside

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -158,7 +158,7 @@ func TestQueueClosed(t *testing.T) {
 	f := New(nil)
 	q := f.Start()
 	q.Close()
-	_, err := q.SendStringGet("a")
+	_, err := q.SendStringGet("http://host/a")
 	if err != ErrQueueClosed {
 		t.Errorf("expected error %s, got %v", ErrQueueClosed, err)
 	}
@@ -221,7 +221,7 @@ func TestSendVariadic(t *testing.T) {
 
 	// Define the raw URLs to enqueue
 	cases := []string{srv.URL + "/a", srv.URL + "/b", "/nohost", ":"}
-	handled := cases[:len(cases)-1]
+	handled := cases[:len(cases)-2]
 
 	// Start the Fetcher
 	sh := &spyHandler{}
@@ -229,11 +229,11 @@ func TestSendVariadic(t *testing.T) {
 	f.CrawlDelay = 0
 	q := f.Start()
 	n, err := q.SendStringGet(cases...)
-	if n != len(handled) {
-		t.Errorf("expected %d URLs enqueued, got %d", len(handled), n)
+	if n != 2 {
+		t.Errorf("expected %d URLs enqueued, got %d", 2, n)
 	}
-	if _, ok := err.(*url.Error); !ok {
-		t.Errorf("expected parse error, got %v", err)
+	if err != ErrEmptyHost {
+		t.Errorf("expected %v, got %v", ErrEmptyHost, err)
 	}
 	// Stop to wait for all commands to be processed
 	q.Close()
@@ -241,13 +241,9 @@ func TestSendVariadic(t *testing.T) {
 	if ok := sh.CalledWithExactly(handled...); !ok {
 		t.Error("expected handler to be called with valid cases")
 	}
-	// Expect 1 error for empty host
-	if cnt := sh.Errors(); cnt != 1 {
-		t.Errorf("expected 1 error, got %d", cnt)
-	}
-	// Assert that the empty host error is actually that error
-	if err := sh.ErrorFor(handled[len(handled)-1]); err != ErrEmptyHost {
-		t.Errorf("expected error %s for url '%s', got %v", ErrEmptyHost, handled[len(handled)-1], err)
+	// Expect no error
+	if cnt := sh.Errors(); cnt != 0 {
+		t.Errorf("expected no error, got %d", cnt)
 	}
 }
 

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -468,7 +468,7 @@ Crawl-delay: 1
 		t.Errorf("expected no errors, got %d", cnt)
 	}
 	// Assert that the total elapsed time is around 4 seconds
-	if delay < 4*time.Second || delay > (4*time.Second+10*time.Millisecond) {
+	if delay < 4*time.Second || delay > (4*time.Second+100*time.Millisecond) {
 		t.Errorf("expected delay to be around 4s, got %s", delay)
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -85,7 +85,7 @@ func (mux *Mux) Handle(ctx *Context, res *http.Response, err error) {
 		// Find a matching response handler
 		var h Handler
 		var n = -1
-		for r, _ := range mux.res {
+		for r := range mux.res {
 			if ok, cnt := r.match(res); ok {
 				if cnt > n {
 					h, n = r.h, cnt

--- a/handler_test.go
+++ b/handler_test.go
@@ -80,17 +80,16 @@ Disallow: /deny
 		url   string
 		trace string
 	}{
-		0:  {"/a", "e"},               // empty host error
-		1:  {srv2.URL + "/none", "d"}, // no specific handler, use default
-		2:  {srv1.URL + "/json", "j"}, // json-specific handler
-		3:  {srv1.URL + "/deny", "a"}, // ErrDisallowed, use any errors handler
-		4:  {srv1.URL + "/a", "g"},    // GET text/html
-		5:  {srv1.URL + "/204", "s"},  // status 204
-		6:  {srv1.URL + "/4xx", "r"},  // status range 4xx
-		7:  {srv1.URL + "/b", "p"},    // path-specific handler
-		8:  {srv1.URL + "/baba", "q"}, // path-specific handler
-		9:  {srv1.URL + "/b/c", "p"},  // path-specific handler
-		10: {srv2.URL + "/zz", "r"},   // custom predicate
+		0: {srv2.URL + "/none", "d"}, // no specific handler, use default
+		1: {srv1.URL + "/json", "j"}, // json-specific handler
+		2: {srv1.URL + "/deny", "a"}, // ErrDisallowed, use any errors handler
+		3: {srv1.URL + "/a", "g"},    // GET text/html
+		4: {srv1.URL + "/204", "s"},  // status 204
+		5: {srv1.URL + "/4xx", "r"},  // status range 4xx
+		6: {srv1.URL + "/b", "p"},    // path-specific handler
+		7: {srv1.URL + "/baba", "q"}, // path-specific handler
+		8: {srv1.URL + "/b/c", "p"},  // path-specific handler
+		9: {srv2.URL + "/zz", "r"},   // custom predicate
 	}
 	// Start the fetcher
 	mux := NewMux()


### PR DESCRIPTION
See #11 , this allows setting a specific callback Handler (or HandlerFunc) on the Command so that the function that will process the response can be set when the URL is enqueued. This takes precedence over the Handler on the Fetcher.

/cc @mmcdole
 