### PR TITLE
add fetcher.HostExists() for checking if the host is already handled

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -104,6 +104,16 @@ type DebugInfo struct {
 	NumHosts int
 }
 
+// HostExists returns if the given host has dedicated channel or not.
+func (f *Fetcher) HostExists(host string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.hosts[host]; ok {
+		return false
+	}
+	return true
+}
+
 // New returns an initialized Fetcher.
 func New(h Handler) *Fetcher {
 	return &Fetcher{

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -716,3 +716,26 @@ func TestCancel(t *testing.T) {
 		t.Errorf("expected no errors, got %d", cnt)
 	}
 }
+
+func TestFetcherHosts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	// Start the Fetcher
+	sh := &spyHandler{}
+	f := New(sh)
+	f.CrawlDelay = 1
+	q := f.Start()
+	if _, err := q.SendStringGet(srv.URL); err != nil {
+		t.Fatal(err)
+	}
+	q.Close()
+	if cnt := sh.Errors(); cnt > 0 {
+		t.Errorf("expected no errors, got %d", cnt)
+	}
+	if f.HostExists(srv.URL) == false {
+		t.Errorf("expected the srv host has handled by a fetcher, but not.\n")
+	}
+}


### PR DESCRIPTION
I try to add `HostExists()` api for a fetcher. It's provided a feature for checking if the given host is already handled by the fetcher. 

For example,

    fetcher.HostExists("http://example.com")

returns if the host "http://example.com" is already under the fetcher.