### PR TITLE
catch email links in full example

### DIFF
--- a/example/full/main.go
+++ b/example/full/main.go
@@ -205,6 +205,18 @@ func enqueueLinks(ctx *fetchbot.Context, doc *goquery.Document) {
 			fmt.Printf("error: resolve URL %s - %s\n", val, err)
 			return
 		}
+
+		// check whether or not the link is an email link
+		emailCheck := false
+		func(s string, emailCheck *bool) {
+			if strings.Contains(s, "mailto:") {
+				*emailCheck = true
+			}
+		}(u.String(), &emailCheck)
+		if emailCheck == true {
+			return
+		}
+
 		if !dup[u.String()] {
 			if _, err := ctx.Q.SendStringHead(u.String()); err != nil {
 				fmt.Printf("error: enqueue head %s - %s\n", u, err)


### PR DESCRIPTION
Because the goquery function will grab all the links nested on the page it will also bring back "**mailto:**" links. In this example it will throw a runtime error in the [processChan](https://github.com/PuerkitoBio/fetchbot/blob/master/fetch.go#L305) function.

This is just a small boolean check so it a page has an email link it will just skip over it.